### PR TITLE
Remove default features from serde

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ std = ["thiserror/default"]
 paste = "1"
 thiserror = { version = "2", default-features = false }
 
-serde = { version = "1.0", features = ["derive"], optional = true }
+serde = { version = "1.0", features = ["derive"], default-features = false, optional = true }
 
 [dev-dependencies]
 bincode = "1"


### PR DESCRIPTION
Serde has a `std` default feature, which drags `std` into the dependency tree, if one want to use this crate with the `serde` feature.

This PR fixes this by explicitly disabling the default features of `serde` dependency of this crate. Thus allowing to using this crate with its `serde` feature in a `no_std` environment.